### PR TITLE
Added: `missed_peer` attribute for RtprSession and MediaSession

### DIFF
--- a/src/main/kotlin/io/sip3/salto/ce/Attributes.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/Attributes.kt
@@ -42,6 +42,7 @@ object Attributes {
     const val r_factor = "r_factor"
     const val one_way = "one_way"
     const val undefined_codec = "undefined_codec"
+    const val missed_peer = "missed_peer"
     const val bad_report_fraction = "bad_report_fraction"
     const val overlapped_interval = "overlapped_interval"
     const val overlapped_fraction = "overlapped_fraction"

--- a/src/main/kotlin/io/sip3/salto/ce/media/MediaHandler.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/media/MediaHandler.kt
@@ -214,6 +214,8 @@ open class MediaHandler : AbstractVerticle() {
             put(Attributes.r_factor, session.rFactor)
             put(Attributes.one_way, session.isOneWay)
             put(Attributes.undefined_codec, session.hasUndefinedCodec)
+            put(Attributes.missed_peer, session.missedPeer)
+
             put(Attributes.bad_report_fraction, session.badReportFraction)
         }
 
@@ -248,6 +250,7 @@ open class MediaHandler : AbstractVerticle() {
 
                 put("one_way", session.isOneWay)
                 put("undefined_codec", session.hasUndefinedCodec)
+                put("missed_peer", session.missedPeer)
 
                 put("mos", session.mos)
                 put("r_factor", session.rFactor)
@@ -264,8 +267,8 @@ open class MediaHandler : AbstractVerticle() {
 
     private fun RtprSession.toJson(): JsonObject {
         return JsonObject().apply {
-            put("created_at", report.startedAt)
-            put("terminated_at", report.startedAt + report.duration)
+            put("created_at", createdAt)
+            put("terminated_at", createdAt + report.duration)
 
             put("src_addr", srcAddr.addr)
             put("src_port", srcAddr.port)
@@ -298,6 +301,8 @@ open class MediaHandler : AbstractVerticle() {
             put("r_factor", report.rFactor.toDouble())
             put("mos", report.mos.toDouble())
             put("fraction_lost", report.fractionLost.toDouble())
+
+            put("missed_peer", missedPeer)
         }
     }
 }

--- a/src/main/kotlin/io/sip3/salto/ce/media/MediaSession.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/media/MediaSession.kt
@@ -45,6 +45,9 @@ class MediaSession(val srcAddr: Address, val dstAddr: Address, val mediaControl:
     val hasUndefinedCodec: Boolean
         get() = codecNames.any { it.contains("UNDEFINED") }
 
+    val missedPeer: Boolean
+        get() = forward.missedPeer || reverse.missedPeer
+
     val mos: Double
         get() {
             return if (forward.mos == null) {
@@ -152,6 +155,9 @@ class MediaSession(val srcAddr: Address, val dstAddr: Address, val mediaControl:
 
         val rFactor: Double?
             get() = rtp?.rFactor ?: rtcp?.rFactor
+
+        val missedPeer: Boolean
+            get() = rtp?.missedPeer ?: false
 
         fun addRtp(session: RtprSession) {
             if (rtp == null) {

--- a/src/main/kotlin/io/sip3/salto/ce/rtpr/RtprSession.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/rtpr/RtprSession.kt
@@ -26,8 +26,8 @@ class RtprSession(packet: Packet, private val rFactorThreshold: Float? = null) {
     var createdAt: Long = 0L
     var terminatedAt: Long = 0L
 
-    val srcAddr = packet.srcAddr
-    val dstAddr = packet.dstAddr
+    var srcAddr = packet.srcAddr
+    var dstAddr = packet.dstAddr
     lateinit var report: RtpReportPayload
 
     var mediaControl: MediaControl? = null
@@ -43,6 +43,8 @@ class RtprSession(packet: Packet, private val rFactorThreshold: Float? = null) {
 
     var reportCount = 0
     var badReportCount = 0
+
+    var missedPeer = false
 
     fun add(payload: RtpReportPayload) {
         if (reportCount == 0) {
@@ -63,6 +65,16 @@ class RtprSession(packet: Packet, private val rFactorThreshold: Float? = null) {
 
         reportCount += other.reportCount
         badReportCount += other.badReportCount
+
+        if (srcAddr != other.srcAddr) {
+            missedPeer = true
+            srcAddr = other.srcAddr
+        }
+
+        if (dstAddr != other.dstAddr) {
+            missedPeer = true
+            dstAddr = other.dstAddr
+        }
     }
 
     private fun mergeReport(payload: RtpReportPayload, reportCountIncrement: Int = 1) {
@@ -111,6 +123,7 @@ class RtprSession(packet: Packet, private val rFactorThreshold: Float? = null) {
 
         if (createdAt > payload.startedAt) {
             createdAt = payload.startedAt
+            report.startedAt = payload.startedAt
         }
 
         if (payload.startedAt + payload.duration > terminatedAt) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,7 +141,7 @@ server:
 #      max-collections: 30
 #    - prefix: rtpr_media_index
 #      indexes:
-#        ascending: [created_at, src_addr, src_host, dst_addr, dst_host, mos, r_factor, bad_report_fraction, forward_rtp.mos, forward_rtp.r_factor, forward_rtcp.mos, forward_rtcp.r_factor, reverse_rtp.mos, reverse_rtp.r_factor, reverse_rtcp.mos, reverse_rtcp.r_factor]
+#        ascending: [created_at, src_addr, src_host, dst_addr, dst_host, mos, r_factor, bad_report_fraction, missed_peer, forward_rtp.mos, forward_rtp.r_factor, forward_rtcp.mos, forward_rtcp.r_factor, reverse_rtp.mos, reverse_rtp.r_factor, reverse_rtcp.mos, reverse_rtcp.r_factor]
 #        hashed: [call_id]
 #      max-collections: 30
 #    - prefix: rtpr_rtp_raw

--- a/src/test/kotlin/io/sip3/salto/ce/media/MediaHandlerTest.kt
+++ b/src/test/kotlin/io/sip3/salto/ce/media/MediaHandlerTest.kt
@@ -160,6 +160,7 @@ class MediaHandlerTest : VertxTest() {
         val RTPR_SESSION_1 = RtprSession(PACKET_1).apply {
             mediaControl = MEDIA_CONTROL
             add(RTPR_1)
+            missedPeer = true
         }
 
         val RTPR_SESSION_2 = RtprSession(PACKET_2).apply {
@@ -203,6 +204,7 @@ class MediaHandlerTest : VertxTest() {
 
                         assertEquals(false, document.getBoolean("one_way"))
                         assertEquals(false, document.getBoolean("undefined_codec"))
+                        assertEquals(true, document.getBoolean("missed_peer"))
 
                         assertEquals(MEDIA_CONTROL.callId, document.getString("call_id"))
                         document.getJsonArray("codec_names").toList().let { codecNames ->
@@ -222,6 +224,8 @@ class MediaHandlerTest : VertxTest() {
                             assertEquals(RTPR_1.rFactor, forwardRtp.getFloat("r_factor"))
                             assertEquals(RTPR_1.mos, forwardRtp.getFloat("mos"))
                             assertEquals(RTPR_1.fractionLost, forwardRtp.getFloat("fraction_lost"))
+
+                            assertEquals(true, document.getBoolean("missed_peer"))
                         }
 
                         document.getJsonObject("reverse_rtp").let { reverseRtp ->
@@ -308,11 +312,12 @@ class MediaHandlerTest : VertxTest() {
 
                     context.verify {
                         assertEquals("media", prefix)
-                        assertEquals(5, attributes.size)
+                        assertEquals(6, attributes.size)
                         assertEquals(12.0, attributes[Attributes.r_factor])
                         assertEquals(13.0, attributes[Attributes.mos])
                         assertEquals(false, attributes[Attributes.one_way])
                         assertEquals(false, attributes[Attributes.undefined_codec])
+                        assertEquals(true, attributes[Attributes.missed_peer])
                         assertEquals(0.0, attributes[Attributes.bad_report_fraction])
                     }
                     context.completeNow()

--- a/src/test/kotlin/io/sip3/salto/ce/media/MediaSessionTest.kt
+++ b/src/test/kotlin/io/sip3/salto/ce/media/MediaSessionTest.kt
@@ -194,6 +194,7 @@ class MediaSessionTest {
         val RTPR_SESSION_1 = RtprSession(PACKET_1).apply {
             mediaControl = MEDIA_CONTROL
             add(RTPR_1)
+            missedPeer = true
         }
 
         val RTPR_SESSION_1_RTCP = RtprSession(PACKET_1_RTCP).apply {
@@ -254,6 +255,7 @@ class MediaSessionTest {
         assertEquals(1, session.codecNames.size)
         assertFalse(session.isOneWay)
         assertFalse(session.hasUndefinedCodec)
+        assertTrue(session.missedPeer)
 
         assertEquals(RTPR_SESSION_1.mos, session.mos)
         assertEquals(RTPR_SESSION_1.rFactor, session.rFactor)

--- a/src/test/kotlin/io/sip3/salto/ce/rtpr/RtprSessionTest.kt
+++ b/src/test/kotlin/io/sip3/salto/ce/rtpr/RtprSessionTest.kt
@@ -226,6 +226,36 @@ class RtprSessionTest {
     }
 
     @Test
+    fun `Validate RtprSession 'merge()' method from RTP with address change`() {
+        val session = RtprSession(PACKET_1).apply {
+            mediaControl = MEDIA_CONTROL
+            RtpReportPayload().apply {
+                decode(RTPR_1.encode())
+            }.let { add(it) }
+        }
+
+        val modifiedPacker = Packet().apply {
+            srcAddr = MEDIA_CONTROL.sdpSession.src.rtpAddress()
+            dstAddr = MediaAddress().apply {
+                addr = "10.20.20.20"
+                rtpPort = 20510
+            }.rtpAddress()
+        }
+        val session2 = RtprSession(modifiedPacker).apply {
+            mediaControl = MEDIA_CONTROL
+            add(RTPR_2)
+        }
+
+        session.merge(session2)
+
+        assertEquals(2, session.reportCount)
+
+        assertTrue(session.missedPeer)
+        assertEquals(session.dstAddr, modifiedPacker.dstAddr)
+        assertEquals(session.dstAddr, modifiedPacker.dstAddr)
+    }
+
+    @Test
     fun `Validate RtprSession R-Factor threshold`() {
         val session = RtprSession(PACKET_1, 50F).apply {
             mediaControl = MEDIA_CONTROL


### PR DESCRIPTION
Modified: Update `srdAddr` and `dstAddr` if new one appears