### PR TITLE
Added: `config-request` and `config` message types in ManagementSocket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/kotlin/io/sip3/salto/ce/host/HostRegistry.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/host/HostRegistry.kt
@@ -17,6 +17,8 @@
 package io.sip3.salto.ce.host
 
 import io.sip3.salto.ce.MongoClient
+import io.vertx.core.Future
+import io.vertx.core.Promise
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.kotlin.ext.mongo.updateOptionsOf
@@ -94,6 +96,18 @@ object HostRegistry {
                 }
             }
         }
+    }
+
+    fun getConfig(name: String): Future<JsonObject> {
+        val promise = Promise.promise<JsonObject>()
+        val query = JsonObject().apply {
+            put("name", name)
+        }
+        client!!.findOne("configuration", query, JsonObject())
+            .onFailure { promise.fail(it) }
+            .onSuccess { promise.complete(it ?: JsonObject()) }
+
+        return promise.future()
     }
 
     private fun updateHosts() {

--- a/src/main/kotlin/io/sip3/salto/ce/host/HostRegistry.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/host/HostRegistry.kt
@@ -18,7 +18,6 @@ package io.sip3.salto.ce.host
 
 import io.sip3.salto.ce.MongoClient
 import io.vertx.core.Future
-import io.vertx.core.Promise
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.kotlin.ext.mongo.updateOptionsOf
@@ -98,16 +97,17 @@ object HostRegistry {
         }
     }
 
-    fun getConfig(name: String): Future<JsonObject> {
-        val promise = Promise.promise<JsonObject>()
+    fun getConfig(name: String): Future<JsonObject?> {
         val query = JsonObject().apply {
             put("name", name)
         }
-        client!!.findOne("configuration", query, JsonObject())
-            .onFailure { promise.fail(it) }
-            .onSuccess { promise.complete(it ?: JsonObject()) }
 
-        return promise.future()
+        return client!!.findOne("configuration", query, JsonObject())
+            .map { config ->
+                config?.apply {
+                    remove("_id")
+                }
+            }
     }
 
     private fun updateHosts() {

--- a/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
@@ -172,10 +172,9 @@ open class ManagementSocket : AbstractVerticle() {
                 hostRegistry.getConfig(name)
                     .onFailure { logger.error(it) { "HostRegistry `getConfig()` failed. Name: $name"} }
                     .onSuccess { config ->
-                        config.remove("_id")
                         val response = JsonObject().apply {
                             put("type", TYPE_CONFIG)
-                            put("payload", config)
+                            put("payload", config ?: JsonObject())
                         }
 
                         socket.send(response.toBuffer(), socketAddress.port(), socketAddress.host())

--- a/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
@@ -43,7 +43,7 @@ open class ManagementSocket : AbstractVerticle() {
     companion object {
 
         const val TYPE_SHUTDOWN = "shutdown"
-        const val TYPE_CONFIG_REQUEST = "config-request"
+        const val TYPE_CONFIG_REQUEST = "config_request"
         const val TYPE_CONFIG = "config"
         const val TYPE_REGISTER = "register"
         const val TYPE_MEDIA_CONTROL = "media_control"

--- a/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/socket/ManagementSocket.kt
@@ -43,6 +43,8 @@ open class ManagementSocket : AbstractVerticle() {
     companion object {
 
         const val TYPE_SHUTDOWN = "shutdown"
+        const val TYPE_CONFIG_REQUEST = "config-request"
+        const val TYPE_CONFIG = "config"
         const val TYPE_REGISTER = "register"
         const val TYPE_MEDIA_CONTROL = "media_control"
         const val TYPE_MEDIA_RECORDING_RESET = "media_recording_reset"
@@ -164,6 +166,20 @@ open class ManagementSocket : AbstractVerticle() {
 
                     lastUpdate = System.currentTimeMillis()
                 }
+            }
+            TYPE_CONFIG_REQUEST -> {
+                val name = payload.getString("name")
+                hostRegistry.getConfig(name)
+                    .onFailure { logger.error(it) { "HostRegistry `getConfig()` failed. Name: $name"} }
+                    .onSuccess { config ->
+                        config.remove("_id")
+                        val response = JsonObject().apply {
+                            put("type", TYPE_CONFIG)
+                            put("payload", config)
+                        }
+
+                        socket.send(response.toBuffer(), socketAddress.port(), socketAddress.host())
+                    }
             }
             TYPE_SHUTDOWN -> {
                 val name = payload.getString("name")


### PR DESCRIPTION
Added: Get config for host by name
Fixed: Exclude `slf4j-api` from `testcontainers`