### PR TITLE
Removed: Getting component configuration from HostRegistry

### DIFF
--- a/src/main/kotlin/io/sip3/salto/ce/management/host/HostRegistry.kt
+++ b/src/main/kotlin/io/sip3/salto/ce/management/host/HostRegistry.kt
@@ -17,7 +17,6 @@
 package io.sip3.salto.ce.management.host
 
 import io.sip3.commons.mongo.MongoClient
-import io.vertx.core.Future
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.kotlin.ext.mongo.updateOptionsOf
@@ -90,20 +89,6 @@ object HostRegistry {
                 logger.error(asr.cause()) { "MongoClient 'replaceDocumentsWithOptions()' failed." }
             }
         }
-    }
-
-    fun getConfig(name: String): Future<JsonObject?> {
-        val query = JsonObject().apply {
-            put("name", name)
-        }
-
-        return client.findOne("configurations", query, JsonObject())
-            .map { config ->
-                config?.apply {
-                    remove("_id")
-                    remove("_class")
-                }
-            }
     }
 
     private fun updateHosts() {


### PR DESCRIPTION
Modified: Salto component has always `mediaEnabled` in `false`
Added: Response message for Captain Register message